### PR TITLE
KAS-3278 Pub v3.2: Government domain full name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ contains the errors encountered during the conversion
 ## Reference
 ### API
 ```
-POST /ingest?range=start,end&take=number
+POST /ingest?range=start,end&take=number&dossiernummer=123252,321240
 ```
 Endpoint to start a conversion.
 
 One of the following query params can be specified to run the conversion only on a subset of publications from the Access DB
 - `range`: specifying number of start and end nod
 - `take`: taking each `take`th element into account
-
+- `dossiernummer`: specify dossiernummer(s)

--- a/configuration/government-domains-full-name.csv
+++ b/configuration/government-domains-full-name.csv
@@ -1,0 +1,16 @@
+DAR;Diensten Algemeen Regeringsbeleid
+IV;Internationaal Vlaanderen
+OV;Onderwijs en Vorming
+CJSM;Cultuur, Jeugd, Sport en Media
+LV;Landbouw en Visserij
+MOW;Mobiliteit en Openbare Werken
+BZ;Bestuurszaken
+FB;Financiën en Begroting
+EWI;Economie, Wetenschap en Innovatie
+WVG;Welzijn, Volksgezondheid en Gezin
+WSE;Werk en Sociale Economie
+LNE;Leefmilieu, Natuur en Energie
+RWO;Ruimtelijke Ordening, Woonbeleid en Onroerend Erfgoed
+KB;Kanselarij en Bestuur
+OMG;Omgeving
+KBBJ;Kanselarij, Bestuur, Buitenlandse Zaken en Justitie

--- a/conversion.rb
+++ b/conversion.rb
@@ -89,6 +89,7 @@ def run(publicaties = nil)
     end
   end
 
+  $errors_csv.close
   Mu.log.info "Processed #{publicaties.size} records."
 
 end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -25,6 +25,11 @@ module Configuration
       return CSV.open path, "rt", encoding: "UTF-8"
     end
 
+    def self.government_domains_full_name &block
+      path = File.join("/app/configuration/government-domains-full-name.csv")
+      return CSV.open path, "rt", encoding: "UTF-8", col_sep: ';', &block
+    end
+
     def self.mandatees_corrections
       path = File.join("/app/configuration/mandatees-corrections.csv")
       return CSV.open path, "rt", encoding: "UTF-8"

--- a/lib/convert_government_domains.rb
+++ b/lib/convert_government_domains.rb
@@ -26,17 +26,19 @@ module ConvertGovernmentDomains
     validate_entries publication_records
   end
 
+  # @param [Enumerator::Lazy] publication_records 
   def self.validate_mapping mapping
     records = query_mapping mapping
     
     export_mapping records
 
     not_found = records.select { |r| r[2].nil? }
-    if !not_found.empty?
+    if not_found.any?
       raise StandardError.new "Incorrect government domain mapping"
     end
   end
 
+  # @param [Enumerator::Lazy] publication_records 
   def self.validate_entries publication_records
     beleidsdomeinen = publication_records.flat_map { |r| prepare r }.uniq
     not_found = beleidsdomeinen.select do |domein|
@@ -44,7 +46,8 @@ module ConvertGovernmentDomains
       required = !(@ignore_set === domein)
       next not_found && required
     end
-    if !not_found.empty?
+    
+    if not_found.any?
       raise StandardError.new "Unknown govenment domains: #{ not_found.join "," }"
     end
   end

--- a/lib/convert_government_domains.rb
+++ b/lib/convert_government_domains.rb
@@ -1,3 +1,4 @@
+# TODO: government domains data model is under consideration
 module ConvertGovernmentDomains
   def self.initialize
     @mapping = setup_mapping

--- a/lib/convert_government_domains_full_name.rb
+++ b/lib/convert_government_domains_full_name.rb
@@ -16,6 +16,7 @@ module ConvertGovernmentDomainsFullName
     validate_entries publication_records
   end
 
+  # @param [Enumerator::Lazy] publication_records 
   def self.validate_entries publication_records
     beleidsdomein_accdb_list = publication_records.flat_map { |r| prepare r }.uniq
     not_found = beleidsdomein_accdb_list.select do |domein|
@@ -23,8 +24,9 @@ module ConvertGovernmentDomainsFullName
       required = !(@ignore_set === domein)
       next not_found && required
     end
-    if !not_found.empty?
-      raise StandardError.new "Unknown govenment domains: #{ not_found.join "," }"
+
+    if not_found.any?
+      raise StandardError.new "Unknown govenment domains: #{ not_found.to_a.join "," }"
     end
   end
 

--- a/lib/convert_government_domains_full_name.rb
+++ b/lib/convert_government_domains_full_name.rb
@@ -1,0 +1,60 @@
+module ConvertGovernmentDomainsFullName
+  def self.initialize
+    @mapping = setup_mapping
+  end
+
+  def self.setup_mapping
+    Configuration::Files.government_domains_full_name do |csv|
+      mapping_raw = csv.to_h
+      mapping_raw.map { |abbr, full_name|
+        [abbr.strip.downcase, full_name.strip]
+      } .to_h
+    end
+  end
+
+  def self.validate publication_records
+    validate_entries publication_records
+  end
+
+  def self.validate_entries publication_records
+    beleidsdomein_accdb_list = publication_records.flat_map { |r| prepare r }.uniq
+    not_found = beleidsdomein_accdb_list.select do |domein|
+      not_found = !(@mapping.include? domein)
+      required = !(@ignore_set === domein)
+      next not_found && required
+    end
+    if !not_found.empty?
+      raise StandardError.new "Unknown govenment domains: #{ not_found.join "," }"
+    end
+  end
+
+  def self.prepare rec
+    beleidsdomein_field_accdb = rec.beleidsdomein
+    
+    return [] if beleidsdomein_field_accdb.nil?
+
+    beleidsdomein_list_accdb = beleidsdomein_field_accdb.split '/'
+    return beleidsdomein_list_accdb.map { |d| d.strip.downcase }
+  end
+
+  # @return [Array] always returns an array (empty if no results)
+  def self.convert rec
+    beleidsdomein_list_accdb = prepare rec
+
+    return beleidsdomein_list_accdb.filter_map { |beleidsdomein_accdb|
+      convert_entry beleidsdomein_accdb
+    }
+  end
+
+  def self.convert_entry beleidsdomein_accdb
+    full_name = @mapping[beleidsdomein_accdb]
+    if full_name.nil?
+      $errors_csv << [rec.dossiernummer, "government-domain", "not-found", d]
+      return
+    end
+
+    return full_name
+  end
+
+  initialize
+end

--- a/web.rb
+++ b/web.rb
@@ -3,10 +3,13 @@ require_relative './conversion.rb'
 post '/ingest' do
   range = params['range']&.split(',')&.map { |s| s.to_i }
   take = params['take']&.to_i
+  dossiernummer_list = params['dossiernummer']&.split(',')
   if range
     records = AccessDB.nodes[(range[0]..range[1])]
   elsif take
     records = AccessDB.nodes.select.with_index { |_, i| i % take === 0 }
+  elsif dossiernummer_list
+    records = AccessDB.by_dossiernummer dossiernummer_list
   end
 
   run(records)


### PR DESCRIPTION
```
⚠️ Ik heb de opdracht hier fout begrepen.
Er moet gewerkt worden met URI's van `skos:Concepts` niet met strings.
```
[kasticketje](https://kanselarij.atlassian.net/browse/KAS-3278)

---
#### Buiten scope
- [x] ensure flush van `errors.csv`