### PR TITLE
bugfix/KAS-3316 Pub Leg C: Save publication number as integer

### DIFF
--- a/exploration-scripts/identifiers_in_access_db.rb
+++ b/exploration-scripts/identifiers_in_access_db.rb
@@ -1,0 +1,28 @@
+recs = AccessDB.records()
+$errors_csv = CSV.open "/data/output/identifiers_in_access_db.csv", mode="w", encoding: "UTF-8"
+
+suffixes = Set.new
+recs.each { |r|
+    dossiernummer = r.dossiernummer
+    if !dossiernummer
+        $errors_csv << ['no-dossiernummer']
+    end
+
+    identifier_match = r.dossiernummer.match '(?<number>\d+)[-/]?(?<version>.+)?'
+    if identifier_match.nil?
+        $errors_csv << ['irregular', r.dossiernummer]
+    else
+        local_id = Integer identifier_match[:number]
+        version_id = identifier_match[:version]&.strip
+        version_id = nil if version_id&.empty?
+        
+    
+        suffixes << version_id if version_id
+    end
+}
+
+(suffixes.to_a.sort_by &:downcase).each { |x|
+    $errors_csv << [x]
+}
+
+$errors_csv.flush


### PR DESCRIPTION
[kasticketje](https://kanselarij.atlassian.net/browse/KAS-3316)

Om een aantal dingen ineens aan te pakken heb ik de parsing van het publicatienummer in een aparte methode gestoken.
Wijzigingen:
- publicatienummers zijn integers
- dossiernummer parsing houdt rekening met - en /
- lege suffixen worden niet gesaved
- skippen van 0-Subsidie-records ermee ingestoken.