### PR TITLE
Feature/kas 3496 number of extracts

### DIFF
--- a/conversion.rb
+++ b/conversion.rb
@@ -8,6 +8,7 @@ require_relative 'lib/convert_reference_document.rb'
 require_relative 'lib/convert_regulation_type.rb'
 require_relative 'lib/convert_government_domains.rb'
 require_relative 'lib/update_number_of_pages.rb'
+require_relative 'lib/update_number_of_extracts.rb'
 
 BASE_URI = 'http://themis.vlaanderen.be/id/%{resource}/%{id}'
 CONCEPT_URI = 'http://themis.vlaanderen.be/id/concept/%{resource}/%{id}'
@@ -99,6 +100,11 @@ def run(publicaties, actions)
   if actions.include? "update--number-of-pages"
     publication_flow_records = publicaties.map { |node| AccessDB.record(node) }
     LegacyPublicationConversion::UpdateNumberOfPages.run publication_flow_records
+  end
+
+  if actions.include? 'update--number-of-extracts'
+    publication_flow_records = publicaties.map { |node| AccessDB.record(node) }
+    LegacyPublicationConversion::UpdateNumberOfExtracts.run publication_flow_records
   end
 end
 

--- a/lib/access_db.rb
+++ b/lib/access_db.rb
@@ -8,6 +8,7 @@ module AccessDB
     bevoegde_ministers: { tag: 'bevoegde_x0020_minister_x0028_s_x0029_' },
     document_nr: { tag: 'document_x0020_nr' },
     aantal_bladzijden: { tag: 'aantal_x0020_blz', type: :integer },
+    aantal_uittreksels: { tag: 'aantal', type: :integer },
     opdrachtgever: { tag: 'opdrachtgever' },
     opdracht_formeel_ontvangen: { tag: 'opdracht_x0020_formeel_x0020_ontvangen', type: :datetime },
     wijze_van_publicatie: { tag: 'wijze_x0020_van_x0020_publicatie' },

--- a/lib/update_number_of_extracts.rb
+++ b/lib/update_number_of_extracts.rb
@@ -1,0 +1,133 @@
+module LegacyPublicationConversion
+  class AbortError < StandardError; end
+
+  module UpdateNumberOfExtracts
+    def self.run records
+      file_timestamp = DateTime.now.strftime('%Y%m%d%H%M%S')
+      publications_ttl_output_file_name = 'legacy-publications--update--number-of-extracts'
+      publications_ttl_output_file = "#{Configuration::Environment.output_dir}/#{file_timestamp}-#{publications_ttl_output_file_name}"
+
+      $errors_csv = CSV.open(
+        "#{Configuration::Environment.output_dir}/#{file_timestamp}-errors.csv", mode = 'a+', encoding: 'UTF-8'
+      )
+
+      Mu.log.info "-- Input file : #{AccessDB.input_file}"
+      Mu.log.info "-- Output file : #{publications_ttl_output_file}"
+
+      kanselarij_graph = RDF::Graph.new
+
+      batch_number = 1
+      batch_size = 1000
+      records.each_with_index do |record, index|
+        dossiernummer = record.dossiernummer
+
+        begin
+          Mu.log.info "Updating number of pages for ##{dossiernummer} (#{index + 1}/#{records.size}) ... "
+
+          kanselarij_graph.transaction(mutable:true) do |tx|
+            $kanselarij_graph = tx
+            process_record record
+          end
+
+          Mu.log.info "Updating number of pages ##{dossiernummer} DONE."
+        rescue AbortError
+          Mu.log.info "Updating number of pages ##{dossiernummer} SKIPPED."
+          # record can not be converted, continue
+        end
+
+        if (index > 0 and index % batch_size == 0) or index == records.size - 1
+          Mu.log.info "[ONGOING] Writing generated data to file for records #{(batch_number - 1) * batch_size + 1} until #{[
+            batch_number * batch_size, index + 1
+          ].min}..."
+          RDF::Writer.open("#{publications_ttl_output_file}-#{batch_number}.ttl") do |writer|
+            writer << kanselarij_graph
+          end
+          File.open("#{publications_ttl_output_file}-#{batch_number}.graph", 'w+') do |f|
+            f.puts(KANSELARIJ_GRAPH)
+          end
+          Mu.log.info 'done'
+          kanselarij_graph = RDF::Graph.new
+          batch_number += 1
+        end
+      end
+
+      $errors_csv.close
+      Mu.log.info "Processed #{records.size} records."
+    end
+
+    def self.process_record rec
+      if not should_convert? rec
+        $errors_csv << [rec.dossiernummer, "skip"]
+        raise AbortError.new "skip #{rec.dossiernummer}"
+      end
+
+      publication_flow_uri, number_of_extracts = query_publication_flow rec
+      if publication_flow_uri.nil?
+        $errors_csv << [rec.dossiernummer, "no-Kaleidos-record", rec.dossiernummer]
+        raise AbortError.new "no-Kaleidos-record #{rec.dossiernummer}"
+      end
+
+      if not number_of_extracts.nil?
+        $errors_csv << [rec.dossiernummer, "number-of-extracts", "exists", rec.dossiernummer]
+        raise AbortError.new "number of extracts exists for #{rec.dossiernummer}"
+      end
+
+      set_number_of_extracts publication_flow_uri, rec
+    end
+
+    # checks whether a publication-flow should be converted
+    # These are the same checks as in conversion.rb
+    def self.should_convert? rec
+      publication_number, publication_number_suffix = convert_publication_number rec
+
+      return false if publication_number == 0 and publication_number_suffix&.downcase == 'subsidie'
+      return false if publication_number.nil?
+      return false if rec.opschrift.nil? and rec.datum.nil? and rec.document_nr.nil?
+      dossier_date = get_dossier_date rec
+      return false if dossier_date.nil?
+
+      return true
+    end
+
+    def self.query_publication_flow rec
+      publication_number, publication_number_suffix = convert_publication_number rec
+      publication_number_full = publication_number.to_s
+      if publication_number_suffix
+        publication_number_full = publication_number_full + ' ' + publication_number_suffix
+      end
+
+      sparql = %{
+        PREFIX adms: <http://www.w3.org/ns/adms#>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+
+        SELECT ?publicationFlowUri ?numberOfExtracts
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+            ?publicationFlowUri adms:identifier ?publicationNumberUri .
+            ?publicationNumberUri skos:notation #{publication_number_full.sparql_escape} .
+            
+            OPTIONAL { ?publicationFlowUri pub:aantalUittreksels ?numberOfExtracts . }
+          }
+        }
+      }
+
+      results = LinkedDB.query(sparql)
+      if results.length === 0
+        $errors_csv << [rec.dossiernummer, 'publication-flow', 'not-found', 'used:', nil, 'query parameters:', rec.dossiernummer, sparql]
+        return
+      elsif results.length >= 1
+        result = results[0]
+        if results.length > 1
+          $errors_csv << [rec.dossiernummer, 'dossier', 'found-multiple', 'used:', result[:publicationFlowUri].value, 'query parameters:' , rec.dossiernummer, sparql]
+        end
+      end
+      
+      return result[:publicationFlowUri], result[:numberOfExtracts]&.value
+    end
+
+    def self.set_number_of_extracts(publication_flow_uri, rec)
+      $kanselarij_graph << RDF.Statement(publication_flow_uri, PUB.aantalUittreksels, rec.aantal_uittreksels) if rec.aantal_uittreksels
+    end
+  end
+end

--- a/lib/update_number_of_extracts.rb
+++ b/lib/update_number_of_extracts.rb
@@ -37,7 +37,7 @@ module LegacyPublicationConversion
           # record can not be converted, continue
         end
 
-        next unless (index % batch_size).zero? || index == records.size - 1
+        next unless ((index + 1) % batch_size).zero? || index == records.size - 1
 
         Mu.log.info "[ONGOING] Writing generated data to file for records "\
                     "#{(batch_number - 1) * batch_size + 1} until #{[batch_number * batch_size, index + 1].min}..."

--- a/lib/update_number_of_extracts.rb
+++ b/lib/update_number_of_extracts.rb
@@ -110,21 +110,21 @@ module LegacyPublicationConversion
         }
       )
       results = LinkedDB.query(sparql)
-      if results.length === 0
-        $errors_csv << [rec.dossiernummer, 'publication-flow', 'not-found', 'used:', nil, 'query parameters:', rec.dossiernummer, sparql]
-        return
-      elsif results.length >= 1
-        result = results[0]
-        if results.length > 1
-          $errors_csv << [rec.dossiernummer, 'dossier', 'found-multiple', 'used:', result[:publicationFlowUri].value, 'query parameters:' , rec.dossiernummer, sparql]
-        end
+      if results.empty?
+        @errors_csv << [rec.dossiernummer, "info - no resource found", sparql]
+        nil
+      elsif results.length > 1
+        @errors_csv << [rec.dossiernummer, "info - found multiple resources", sparql]
+        nil
+      else
+        [results[0][:publicationFlowUri], results[0][:numberOfExtracts]&.value]
       end
-      
-      return result[:publicationFlowUri], result[:numberOfExtracts]&.value
     end
 
     def self.set_number_of_extracts(publication_flow_uri, rec)
-      $kanselarij_graph << RDF.Statement(publication_flow_uri, PUB.aantalUittreksels, rec.aantal_uittreksels) if rec.aantal_uittreksels
+      return unless rec.aantal_uittreksels
+
+      @kanselarij_graph << RDF.Statement(publication_flow_uri, PUB.aantalUittreksels, rec.aantal_uittreksels)
     end
   end
 end


### PR DESCRIPTION
Adds a "mini-conversion" that extracts the number-of-extracts (`aantal`) from existing legacy publications.

It's pretty much a copy of https://github.com/kanselarij-vlaanderen/publication-legacy-conversion/blob/master/lib/update_number_of_pages.rb but for `aantal_uittreksels` instead of `aantal_paginas`

Only difference is that legacy records that match multiple Kaleidos resources get skipped.